### PR TITLE
Fix download link in acronym_setup.md

### DIFF
--- a/docs/acronym_setup.md
+++ b/docs/acronym_setup.md
@@ -4,7 +4,7 @@ Instructions are based off of https://github.com/NVlabs/acronym#using-the-full-a
 
 ## Download Data
 
-1. Download the acronym dataset and extract it to the `acronym/grasps` directory: [acronym.tar.gz](https://drive.google.com/file/d/1zcPARTCQx2oeiKk7a-wdN_CN-RUVX56c/view?usp=sharing)
+1. Download the acronym dataset and extract it to the `acronym/grasps` directory: [acronym.tar.gz](https://drive.google.com/file/d/1OjykLD9YmnFdfYpH2qO8yBo-I-22vKwu/view?usp=sharing)
 
 2. Download the ShapeNetSem meshes (models-OBJ.zip) from [https://www.shapenet.org/](https://www.shapenet.org/) and
 extract it to `acronym/models`.


### PR DESCRIPTION
The old link is outdated and doesn't work anymore.
This is the new google drive link where the dataset is stored.